### PR TITLE
Prefix and redirection from bare domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,12 @@ Module Input Variables
 - `domain_name` - (string) - **REQUIRED** - Domain name to serve as entry points for your service
 - `backend_address` - (string) - **REQUIRED** - Backend address to service requests for your domains
 - `env` - (string) - **REQUIRED** - Environment name - used to build name of resources and conditionally enable/disable certain features of the module
+- `prefix` - (string) - Domain prefix (default: `www`)
 - `caching` - (bool) - Whether to enable / forcefully disable caching (default: `true`)
 - `force_ssl` - (bool) - Controls whether to redirect HTTP -> HTTPS (default: `true`)
 - `connect_timeout` - (string) - How long to wait for a timeout in milliseconds (default: `5000`)
 - `first_byte_timeout` - (string) - How long to wait for the first bytes in milliseconds (default: `60000`)
 - `between_bytes_timeout` - (string) - How long to wait between bytes in milliseconds (default: `30000`)
-
-### domain_name permutations
-
-This module will actually configure two domain names which will be the entry point to the service - with `www` prefix and bare domain, as passed via the parameter.
-On top of this, depending on environment, for `non-live` environments, $env prefix will be added to the domain.
-
-Example full list of permutations for domain `domain.com` (i.e. you pass `domain.com` via `dns_domain` parameter) in all environments will be as following:
-
-| Environment | Domain names configured in Fastly |
-| `live` | `domain.com`, `www.domain.com` |
-| `ci` | `ci.domain.com`, `ci-www.domain.com` |
 
 Usage
 -----

--- a/main.tf
+++ b/main.tf
@@ -75,3 +75,36 @@ resource "fastly_service_v1" "fastly" {
 
   force_destroy = true
 }
+
+# resource performing bare-domain redirection to prefix; only for live
+resource "fastly_service_v1" "fastly_bare_domain_redirection" {
+  name  = "${var.domain_name}-redirection"
+  count = "${var.env == "live" ? 1 : 0}"
+
+  domain {
+    name = "${var.domain_name}"
+  }
+
+  response_object {
+    name              = "redirect_bare_domain_to_prefix"
+    status            = 301
+    response          = "Moved Permanently"
+    request_condition = "all_urls"
+  }
+
+  header {
+    name              = "redirect_bare_domain_to_prefix"
+    destination       = "http.Location"
+    type              = "response"
+    action            = "set"
+    source            = "${format("\"https://%s\" + req.url", var.domain_name)}"
+    request_condition = "all_urls"
+  }
+
+  condition {
+    name      = "all_urls"
+    type      = "REQUEST"
+    priority  = 5
+    statement = "req.url ~ \".*\""
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -2,14 +2,10 @@ resource "fastly_service_v1" "fastly" {
   name = "${var.env}-${var.domain_name}"
 
   domain {
-    name = "${var.env == "live" ? "www." : format("%s-www.", var.env)}${var.domain_name}"
+    name = "${var.env == "live" ? format("%s.", var.prefix) : format("%s-%s.", var.env, var.prefix)}${var.domain_name}"
   }
 
-  domain {
-    name = "${var.env == "live" ? "" : format("%s.", var.env)}${var.domain_name}"
-  }
-
-  default_host = "${var.env == "live" ? "www." : format("%s-www.", var.env)}${var.domain_name}"
+  default_host = "${var.env == "live" ? format("%s.", var.prefix) : format("%s-%s.", var.env, var.prefix)}${var.domain_name}"
   default_ttl  = 60
 
   backend {

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -8,6 +8,15 @@ module "fastly" {
   env             = "${var.env}"
 }
 
+module "fastly_custom_prefix" {
+  source = "../.."
+
+  domain_name     = "${var.domain_name}"
+  backend_address = "${var.backend_address}"
+  env             = "${var.env}"
+  prefix          = "${var.prefix}"
+}
+
 module "fastly_custom_timeouts" {
   source = "../.."
 
@@ -43,6 +52,10 @@ variable "domain_name" {}
 variable "backend_address" {}
 
 variable "env" {}
+
+variable "prefix" {
+  default = "www"
+}
 
 variable "caching" {
   default = "true"

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -34,15 +34,75 @@ class TestTFFastlyFrontend(unittest.TestCase):
 
         # Then
         assert """
-    domain.#:                                     "2"
-    domain.1665706793.comment:                    ""
-    domain.1665706793.name:                       "ci-www.domain.com"
-    domain.469113303.comment:                     ""
-    domain.469113303.name:                        "ci.domain.com"
+    default_host:                                 "ci-www.domain.com"
         """.strip() in output
 
         assert """
-    name:                                         "ci-domain.com"
+    domain.#:                                     "1"
+    domain.1665706793.comment:                    ""
+    domain.1665706793.name:                       "ci-www.domain.com"
+        """.strip() in output
+
+        assert """
+Plan: 1 to add, 0 to change, 0 to destroy.
+        """.strip() in output
+
+    def test_create_fastly_service_with_custom_prefix_ci_env(self):
+        # Given
+
+        # When
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'domain_name=domain.com',
+            '-var', 'backend_address=1.1.1.1',
+            '-var', 'env=ci',
+            '-var', 'prefix=admin',
+            '-target=module.fastly_custom_prefix',
+            '-no-color',
+            'test/infra'
+        ], env=self._env_for_check_output('qwerty')).decode('utf-8')
+
+        # Then
+        assert """
+    default_host:                                 "ci-admin.domain.com"
+        """.strip() in output
+
+        assert """
+    domain.#:                                     "1"
+    domain.4266294051.comment:                    ""
+    domain.4266294051.name:                       "ci-admin.domain.com"
+        """.strip() in output
+
+        assert """
+Plan: 1 to add, 0 to change, 0 to destroy.
+        """.strip() in output
+
+    def test_create_fastly_service_with_custom_prefix_live_env(self):
+        # Given
+
+        # When
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'domain_name=domain.com',
+            '-var', 'backend_address=1.1.1.1',
+            '-var', 'env=live',
+            '-var', 'prefix=admin',
+            '-target=module.fastly_custom_prefix',
+            '-no-color',
+            'test/infra'
+        ], env=self._env_for_check_output('qwerty')).decode('utf-8')
+
+        # Then
+        assert """
+    default_host:                                 "admin.domain.com"
+        """.strip() in output
+
+        assert """
+    domain.#:                                     "1"
+    domain.2052375204.comment:                    ""
+    domain.2052375204.name:                       "admin.domain.com"
         """.strip() in output
 
         assert """

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "env" {
 }
 
 # optional variables
+variable "prefix" {
+  type        = "string"
+  description = "Domain prefix"
+  default     = "www"
+}
+
 variable "caching" {
   type        = "string"
   description = "Whether to or not disable caching on Fastly (default: true)"


### PR DESCRIPTION
This PR implements two changes:

1) Instead of assuming prefix is always `www` - we now can reconfigured it to something else.  This is useful when we eg. want to front something hosted on subdomain (eg. `admin.domain.com`)
2) We create a redirection in Fastly edge for `live` env from bare-domain (eg. `domain.com`) to prefixed domain (eg. `www.domain.com`).

Both changes are result of requirements presented by `product-frontend-boilerplate`.

Tests included.