### PR TITLE
Add ssl_cert_hostname and make secure by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This module creates Fastly Frontend including some conditions, like:
 
 Also, some HTTP headers obfuscation will be configured (http.Server, etc.)
 
-**NOTE:** If you want to use HTTPS you need to set up SSL Certification beforehand 
+**NOTE:** If you want to use HTTPS you need to set up SSL Certification beforehand
 
 Module Input Variables
 ----------------------
@@ -18,6 +18,8 @@ Module Input Variables
 - `prefix` - (string) - Domain prefix (default: `www`)
 - `caching` - (bool) - Whether to enable / forcefully disable caching (default: `true`)
 - `force_ssl` - (bool) - Controls whether to redirect HTTP -> HTTPS (default: `true`)
+- `ssl_cert_check` - (bool) - Check the backend cert is valid - warning disabling this makes you vulnerable to a man-in-the-middle imporsonating your backend (default `true`).
+- `ssl_cert_hostname` - (string) - The hostname to validate the certificate presented by the backend against (default `""`).
 - `connect_timeout` - (string) - How long to wait for a timeout in milliseconds (default: `5000`)
 - `first_byte_timeout` - (string) - How long to wait for the first bytes in milliseconds (default: `60000`)
 - `between_bytes_timeout` - (string) - How long to wait between bytes in milliseconds (default: `30000`)

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,8 @@ resource "fastly_service_v1" "fastly" {
     address               = "${var.backend_address}"
     name                  = "default backend"
     port                  = 443
-    ssl_check_cert        = "false"
+    ssl_check_cert        = "${var.ssl_cert_check}"
+    ssl_cert_hostname     = "${var.ssl_cert_hostname}"
     connect_timeout       = "${var.connect_timeout}"
     first_byte_timeout    = "${var.first_byte_timeout}"
     between_bytes_timeout = "${var.between_bytes_timeout}"

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -40,6 +40,15 @@ module "fastly_disable_force_ssl" {
   force_ssl       = "${var.force_ssl}"
 }
 
+module "fastly_ssl_cert_hostname" {
+  source = "../.."
+
+  domain_name       = "${var.domain_name}"
+  backend_address   = "${var.backend_address}"
+  env               = "${var.env}"
+  ssl_cert_hostname = "${var.ssl_cert_hostname}"
+}
+
 # variables
 variable "domain_name" {}
 
@@ -77,4 +86,8 @@ variable "error_response_503" {
 
 variable "error_response_502" {
   default = "cba"
+}
+
+variable "ssl_cert_hostname" {
+  default = ""
 }

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -417,3 +417,21 @@ Plan: 2 to add, 0 to change, 0 to destroy.
     condition.{ident2}.priority:                "5"
     condition.{ident2}.statement:               "beresp.status == 503"
         """.strip()), output) # noqa
+
+    def test_ssl_cert_hostname(self):
+        # When
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'domain_name=www.domain.com',
+            '-var', 'backend_address=1.1.1.1',
+            '-var', 'env=ci',
+            '-var', 'ssl_cert_hostname=test-hostname',
+            '-target=module.fastly_ssl_cert_hostname',
+            '-no-color',
+            'test/infra'
+        ], env=self._env_for_check_output('qwerty')).decode('utf-8')
+
+        assert re.search(template_to_re("""
+   backend.{ident}.ssl_cert_hostname:         "test-hostname"
+        """.strip()), output) # noqa

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,18 @@ variable "between_bytes_timeout" {
   default     = 30000
 }
 
+variable "ssl_cert_check" {
+  type        = "string"
+  description = "Should the backend SSL cert be checked - warning turning this off may reduce security."
+  default     = "true"
+}
+
+variable "ssl_cert_hostname" {
+  type        = "string"
+  description = "The hostname to validate the certificate presented by the backend against."
+  default     = ""
+}
+
 variable "error_response_503" {
   type        = "string"
   description = "The html error document to send when we get a service unavailable from the backend."


### PR DESCRIPTION
This adds an option to set the hostname that the backend certificate
will be validated against, and turns on checking of the backend cert to
make the module secure by default.

JIRA: PLAT-1018