### PR TITLE
Use a single proxy error response

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Module Input Variables
 - `connect_timeout` - (string) - How long to wait for a timeout in milliseconds (default: `5000`)
 - `first_byte_timeout` - (string) - How long to wait for the first bytes in milliseconds (default: `60000`)
 - `between_bytes_timeout` - (string) - How long to wait between bytes in milliseconds (default: `30000`)
-- `error_response_502` - (string) - The html error document to send when we get a bad gateway from the backend, or when there is no response from the backend.
-- `error_response_503` - (string) - The html error document to send when we get a service unavailable from the backend.
+- `proxy_error_response` - (string) - The html error document to send for a proxy error - 502/503 from backend, or no response from backend at all.
 
 Usage
 -----

--- a/custom.vcl
+++ b/custom.vcl
@@ -75,7 +75,7 @@ sub vcl_error {
 
  /* handle 5XXs*/
  if (obj.status >= 500 && obj.status < 600) {
-   synthetic {"${error_response_502}"};
+   synthetic {"${proxy_error_response}"};
    return(deliver);
  }
 }

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "fastly_service_v1" "fastly" {
     name            = "error-response-503"
     status          = 503
     response        = "Service Unavailable"
-    content         = "${var.error_response_503}"
+    content         = "${var.proxy_error_response}"
     content_type    = "text/html"
     cache_condition = "response-503-condition"
   }
@@ -80,7 +80,7 @@ resource "fastly_service_v1" "fastly" {
     name            = "error-response-502"
     status          = 502
     response        = "Bad Gateway"
-    content         = "${var.error_response_502}"
+    content         = "${var.proxy_error_response}"
     content_type    = "text/html"
     cache_condition = "response-502-condition"
   }
@@ -121,7 +121,7 @@ data "template_file" "custom_vcl" {
   template = "${file("${path.module}/custom.vcl")}"
 
   vars {
-    error_response_502 = "${var.error_response_502}"
+    proxy_error_response = "${var.proxy_error_response}"
   }
 }
 

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -7,8 +7,7 @@ module "fastly" {
   backend_address           = "${var.backend_address}"
   env                       = "${var.env}"
   bare_redirect_domain_name = "${var.bare_redirect_domain_name}"
-  error_response_502        = "${var.error_response_502}"
-  error_response_503        = "${var.error_response_503}"
+  proxy_error_response      = "${var.proxy_error_response}"
 }
 
 module "fastly_custom_timeouts" {
@@ -80,12 +79,8 @@ variable "between_bytes_timeout" {
   default = 789
 }
 
-variable "error_response_503" {
+variable "proxy_error_response" {
   default = "abc"
-}
-
-variable "error_response_502" {
-  default = "cba"
 }
 
 variable "ssl_cert_hostname" {

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -347,7 +347,7 @@ Plan: 2 to add, 0 to change, 0 to destroy.
             '-var', 'domain_name=www.domain.com',
             '-var', 'backend_address=1.1.1.1',
             '-var', 'env=ci',
-            '-var', 'error_response_502=<html>502</html>',
+            '-var', 'proxy_error_response=<html>error</html>',
             '-target=module.fastly',
             '-no-color',
             'test/infra'
@@ -355,7 +355,7 @@ Plan: 2 to add, 0 to change, 0 to destroy.
 
         # then
         assert re.search(template_to_re("""
-    response_object.{ident}.content:           "<html>502</html>"
+    response_object.{ident}.content:           "<html>error</html>"
         """.strip()), output)
 
     def test_503_error_condition_page(self):
@@ -366,7 +366,7 @@ Plan: 2 to add, 0 to change, 0 to destroy.
             '-var', 'domain_name=www.domain.com',
             '-var', 'backend_address=1.1.1.1',
             '-var', 'env=ci',
-            '-var', 'error_response_503=<html>503</html>',
+            '-var', 'proxy_error_response=<html>error</html>',
             '-target=module.fastly',
             '-no-color',
             'test/infra'
@@ -374,7 +374,7 @@ Plan: 2 to add, 0 to change, 0 to destroy.
 
         # then
         assert re.search(template_to_re("""
-    response_object.{ident}.content:           "<html>503</html>"
+    response_object.{ident}.content:           "<html>error</html>"
         """.strip()), output)
 
     def test_502_error_condition(self):
@@ -385,7 +385,7 @@ Plan: 2 to add, 0 to change, 0 to destroy.
             '-var', 'domain_name=www.domain.com',
             '-var', 'backend_address=1.1.1.1',
             '-var', 'env=ci',
-            '-var', 'error_response_502=<html>502</html>',
+            '-var', 'proxy_error_response=<html>error</html>',
             '-target=module.fastly',
             '-no-color',
             'test/infra'
@@ -399,9 +399,9 @@ Plan: 2 to add, 0 to change, 0 to destroy.
         """.strip()), output) # noqa
 
         assert re.search(template_to_re("""
-    vcl.{ident}.content:                        "3dbdb5b8ed8816370d0b79075e972079c8bfa103"
-    vcl.{ident}.main:                           "true"
-    vcl.{ident}.name:                           "custom_vcl"
+    vcl.{ident}.content:                       "81d77771d4a92fc470d5e23857dff9ddc0df4b5f"
+    vcl.{ident}.main:                          "true"
+    vcl.{ident}.name:                          "custom_vcl"
         """.strip()), output) # noqa
 
 
@@ -413,7 +413,7 @@ Plan: 2 to add, 0 to change, 0 to destroy.
             '-var', 'domain_name=www.domain.com',
             '-var', 'backend_address=1.1.1.1',
             '-var', 'env=ci',
-            '-var', 'error_response_503=<html>503</html>',
+            '-var', 'proxy_error_response=<html>error</html>',
             '-target=module.fastly',
             '-no-color',
             'test/infra'

--- a/variables.tf
+++ b/variables.tf
@@ -62,38 +62,18 @@ variable "ssl_cert_hostname" {
   default     = ""
 }
 
-variable "error_response_503" {
+variable "proxy_error_response" {
   type        = "string"
-  description = "The html error document to send when we get a service unavailable from the backend."
+  description = "The html error document to send for a proxy error - 502/503 from backend, or no response from backend at all."
 
   default = <<EOF
 <!DOCTYPE html>
 <html>
   <head>
-    <title>503 Service Unavailable</title>
+    <title>Service Unavailable</title>
   </head>
   <body>
-    <h1>Service Unavailable (503)</h1>
-    <p>
-      The site you requested is currently unavailable.
-    </p>
-  </body>
-</html>
-EOF
-}
-
-variable "error_response_502" {
-  type        = "string"
-  description = "The html error document to send when we get a bad gateway from the backend, or when there is no response from the backend."
-
-  default = <<EOF
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>502 Bad Gateway</title>
-  </head>
-  <body>
-    <h1>Bad Gateway (502)</h1>
+    <h1>Service Unavailable</h1>
     <p>
       The site you requested is currently unavailable.
     </p>


### PR DESCRIPTION
The user doesn't really care what type of proxy error occurred, so just
have one option for this response (whilst maintaining the status code
for debugging).