### PR TITLE
Use Logentries LogSet data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Module Input Variables
 - `bare_redirect_domain_name` - (string) - If set, then a service will be created in live to redirect this bare domain to the prefixed version - for example you might set this value to `my-site.com` in order to redirect users to `www.my-site.com`.
 - `backend_address` - (string) - **REQUIRED** - Backend address to service requests for your domains
 - `env` - (string) - **REQUIRED** - Environment name - for non-live environments, will be prefixed with a hyphen onto the start of the domain name. used to build name of resources and conditionally enable/disable certain features of the module
-- `le_logset_id` - (string) - **REQUIRED** - Logentries Logset ID under which Logs will be sent to (provided by platform config)
+- `le_logset_parent_name` - (string) - Parent Logentries Logset name under which Logs will be created (default: `Fastly`)
 - `caching` - (bool) - Whether to enable / forcefully disable caching (default: `true`)
 - `force_ssl` - (bool) - Controls whether to redirect HTTP -> HTTPS (default: `true`)
 - `ssl_cert_check` - (bool) - Check the backend cert is valid - warning disabling this makes you vulnerable to a man-in-the-middle imporsonating your backend (default `true`).
@@ -40,6 +40,5 @@ module "fastly" {
   domain_name         = "domain.com"
   backend_address     = "aws-alb-address.com"
   env                 = "ci"
-  le_logset_id        = "aaaa-bbbb-ccc-ddd"
 }
 ```

--- a/logentries.tf
+++ b/logentries.tf
@@ -1,5 +1,9 @@
+data "logentries_logset" "fastly" {
+  name = "${var.le_logset_parent_name}"
+}
+
 resource "logentries_log" "logs" {
-  logset_id = "${var.le_logset_id}"
+  logset_id = "${data.logentries_logset.fastly.id}"
   name      = "${var.env}-${var.domain_name}"
   source    = "token"
 }

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -5,10 +5,10 @@ ENV TERRAFORM_VERSION=0.10.0-rc1
 
 ENV TERRAFORM_PROVIDER_AWS_VERSION=0.1.3
 ENV TERRAFORM_PROVIDER_FASTLY_VERSION=0.1.2_le-support
+ENV TERRAFORM_PROVIDER_LOGENTRIES_VERSION=0.1.0_logset_datasource
 ENV TERRAFORM_PROVIDER_NULL_VERSION=0.1.0
 ENV TERRAFORM_PROVIDER_TEMPLATE_VERSION=0.1.1
 ENV TERRAFORM_PROVIDER_ACME_VERSION=0.3.0
-ENV TERRAFORM_PROVIDER_LOGENTRIES_VERSION=0.1.0
 
 ENV PYTHONDONTWRITEBYTECODE donot
 
@@ -21,12 +21,12 @@ RUN apk update && apk add ca-certificates curl git openssl wget && \
         unzip terraform-provider-aws_*_linux_amd64.zip -d /usr/bin && \
     wget -q https://s3-eu-west-1.amazonaws.com/mmg-terraform-providers/terraform-provider-fastly_v${TERRAFORM_PROVIDER_FASTLY_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-fastly_*_linux_amd64.zip -d /usr/bin && \
+    wget -q https://s3-eu-west-1.amazonaws.com/mmg-terraform-providers/terraform-provider-logentries_v${TERRAFORM_PROVIDER_LOGENTRIES_VERSION}_linux_amd64.zip && \
+        unzip terraform-provider-logentries_*_linux_amd64.zip -d /usr/bin && \
     wget -q https://releases.hashicorp.com/terraform-provider-null/${TERRAFORM_PROVIDER_NULL_VERSION}/terraform-provider-null_${TERRAFORM_PROVIDER_NULL_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-null_*_linux_amd64.zip -d /usr/bin && \
     wget -q https://releases.hashicorp.com/terraform-provider-template/${TERRAFORM_PROVIDER_TEMPLATE_VERSION}/terraform-provider-template_${TERRAFORM_PROVIDER_TEMPLATE_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-template_*_linux_amd64.zip -d /usr/bin && \
-    wget -q https://releases.hashicorp.com/terraform-provider-logentries/${TERRAFORM_PROVIDER_LOGENTRIES_VERSION}/terraform-provider-logentries_${TERRAFORM_PROVIDER_LOGENTRIES_VERSION}_linux_amd64.zip && \
-            unzip terraform-provider-logentries_*_linux_amd64.zip -d /usr/bin && \
     wget -q https://github.com/paybyphone/terraform-provider-acme/releases/download/v${TERRAFORM_PROVIDER_ACME_VERSION}/terraform-provider-acme_v${TERRAFORM_PROVIDER_ACME_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-acme_*_linux_amd64.zip -d /usr/bin && \
     rm -rf /tmp/* /var/cache/apk/* /var/tmp/*

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -8,7 +8,6 @@ module "fastly" {
   env                       = "${var.env}"
   bare_redirect_domain_name = "${var.bare_redirect_domain_name}"
   proxy_error_response      = "${var.proxy_error_response}"
-  le_logset_id              = "${var.le_logset_id}"
 }
 
 module "fastly_custom_timeouts" {
@@ -20,7 +19,6 @@ module "fastly_custom_timeouts" {
   connect_timeout       = "${var.connect_timeout}"
   first_byte_timeout    = "${var.first_byte_timeout}"
   between_bytes_timeout = "${var.between_bytes_timeout}"
-  le_logset_id          = "${var.le_logset_id}"
 }
 
 module "fastly_disable_caching" {
@@ -30,7 +28,6 @@ module "fastly_disable_caching" {
   backend_address = "${var.backend_address}"
   env             = "${var.env}"
   caching         = "${var.caching}"
-  le_logset_id    = "${var.le_logset_id}"
 }
 
 module "fastly_disable_force_ssl" {
@@ -40,7 +37,6 @@ module "fastly_disable_force_ssl" {
   backend_address = "${var.backend_address}"
   env             = "${var.env}"
   force_ssl       = "${var.force_ssl}"
-  le_logset_id    = "${var.le_logset_id}"
 }
 
 module "fastly_ssl_cert_hostname" {
@@ -50,7 +46,6 @@ module "fastly_ssl_cert_hostname" {
   backend_address   = "${var.backend_address}"
   env               = "${var.env}"
   ssl_cert_hostname = "${var.ssl_cert_hostname}"
-  le_logset_id      = "${var.le_logset_id}"
 }
 
 # variables
@@ -66,10 +61,6 @@ variable "env" {}
 
 variable "caching" {
   default = "true"
-}
-
-variable "le_logset_id" {
-  default = "123"
 }
 
 variable "force_ssl" {

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -113,7 +113,9 @@ Plan: 2 to add, 0 to change, 0 to destroy.
 
         assert re.search(template_to_re("""
   + module.fastly.logentries_log.logs
-      logset_id:        "123"
+        """.strip()), output) # noqa
+
+        assert re.search(template_to_re("""
       name:             "ci-www.domain.com"
       retention_period: "ACCOUNT_DEFAULT"
       source:           "token"

--- a/variables.tf
+++ b/variables.tf
@@ -20,9 +20,10 @@ variable "env" {
   description = "Environment name"
 }
 
-variable "le_logset_id" {
-  description = "Logentries Logset ID"
+variable "le_logset_parent_name" {
+  description = "Logentries Logset Name under which Logs will be created"
   type        = "string"
+  default     = "Fastly"
 }
 
 variable "caching" {


### PR DESCRIPTION
We'd like to be able to use Logentries LogSet data source to pass parent LogSet ID where Logs will be created, instead of passing the ID into the module.

This way we can remove an entry from platform-config making it less complex and thinner.