### PR TITLE
Only use `proxy_error_response` for proxy errors

### DIFF
--- a/custom.vcl
+++ b/custom.vcl
@@ -76,8 +76,8 @@ sub vcl_deliver {
 sub vcl_error {
 #FASTLY error
 
- /* handle 5XXs*/
- if (obj.status >= 500 && obj.status < 600) {
+ /* handle proxy errors */
+ if (obj.status == 502 && obj.status == 503) {
    synthetic {"${proxy_error_response}"};
    return(deliver);
  }

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -440,7 +440,7 @@ Plan: 3 to add, 0 to change, 0 to destroy.
         """.strip()), output) # noqa
 
         assert re.search(template_to_re("""
-      vcl.{ident}.content:                       "6c6520150bf5839c335d24c9d1f745ecd4368858"
+      vcl.{ident}.content:                       "44d442dae21927ea3ce64955cb52472474131d31"
       vcl.{ident}.main:                          "true"
       vcl.{ident}.name:                          "custom_vcl"
         """.strip()), output) # noqa
@@ -499,9 +499,9 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 
         # Then
         assert re.search(template_to_re("""
-      vcl.{ident}.content:                       "9c422a8962b924a7b02be727c1c6253ad45b5d9b"
-      vcl.{ident}.main:                          "true"
-      vcl.{ident}.name:                          "custom_vcl"
+      vcl.{ident}.content:                        "58cd6ad3f54e71d85cdcb5181a79b50d8388a68f"
+      vcl.{ident}.main:                           "true"
+      vcl.{ident}.name:                           "custom_vcl"
         """.strip()), output) # noqa
 
     def test_custom_vcl_recv_added(self):
@@ -520,7 +520,7 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 
         # Then
         assert re.search(template_to_re("""
-      vcl.{ident}.content:                        "61cba4a312d335b8242595abc2eac6d316a62554"
-      vcl.{ident}.main:                           "true"
-      vcl.{ident}.name:                           "custom_vcl"
+      vcl.{ident}.content:                       "257141b00a6922282c4004781dc0672ddb8e2594"
+      vcl.{ident}.main:                          "true"
+      vcl.{ident}.name:                          "custom_vcl"
         """.strip()), output) # noqa


### PR DESCRIPTION
It might be good to have an override for 500 (and even 404) errors, but
this shouldn't be the `proxy_error_response` since this is misleading
(this is specifically to avoid ugly errors when the backend can't be
contacted, or returns an ugly proxy error itself (e.g. if the backend is
an ALB).