### PR TITLE
Add vcl_error hook

### DIFF
--- a/custom.vcl
+++ b/custom.vcl
@@ -81,6 +81,8 @@ sub vcl_error {
    synthetic {"${proxy_error_response}"};
    return(deliver);
  }
+ 
+  ${custom_vcl_error}
 }
 
 sub vcl_pass {

--- a/main.tf
+++ b/main.tf
@@ -129,6 +129,7 @@ data "template_file" "custom_vcl" {
     proxy_error_response = "${var.proxy_error_response}"
     custom_vcl_backends  = "${var.custom_vcl_backends}"
     custom_vcl_recv      = "${var.custom_vcl_recv}"
+    custom_vcl_error     = "${var.custom_vcl_error}"
   }
 }
 

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -9,6 +9,8 @@ module "fastly" {
   bare_redirect_domain_name = "${var.bare_redirect_domain_name}"
   proxy_error_response      = "${var.proxy_error_response}"
   custom_vcl_backends       = "${var.custom_vcl_backends}"
+  custom_vcl_recv           = "${var.custom_vcl_recv}"
+  custom_vcl_error          = "${var.custom_vcl_error}"
 }
 
 module "fastly_custom_timeouts" {
@@ -93,5 +95,9 @@ variable "custom_vcl_backends" {
 }
 
 variable "custom_vcl_recv" {
+  default = ""
+}
+
+variable "custom_vcl_error" {
   default = ""
 }

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -440,7 +440,7 @@ Plan: 3 to add, 0 to change, 0 to destroy.
         """.strip()), output) # noqa
 
         assert re.search(template_to_re("""
-      vcl.{ident}.content:                       "6c6520150bf5839c335d24c9d1f745ecd4368858"
+      vcl.{ident}.content:                       "966b8a0186190d1d2193669e7b9d91855a3c9894"
       vcl.{ident}.main:                          "true"
       vcl.{ident}.name:                          "custom_vcl"
         """.strip()), output) # noqa
@@ -499,7 +499,7 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 
         # Then
         assert re.search(template_to_re("""
-      vcl.{ident}.content:                       "9c422a8962b924a7b02be727c1c6253ad45b5d9b"
+      vcl.{ident}.content:                       "0f6a13d45163c372760485219b3dd609547ab97e"
       vcl.{ident}.main:                          "true"
       vcl.{ident}.name:                          "custom_vcl"
         """.strip()), output) # noqa
@@ -520,7 +520,28 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 
         # Then
         assert re.search(template_to_re("""
-      vcl.{ident}.content:                        "61cba4a312d335b8242595abc2eac6d316a62554"
-      vcl.{ident}.main:                           "true"
-      vcl.{ident}.name:                           "custom_vcl"
+      vcl.{ident}.content:                       "2f8f5541b733b11b4c9badd3cdcbc2fbaa47eb6d"
+      vcl.{ident}.main:                          "true"
+      vcl.{ident}.name:                          "custom_vcl"
+        """.strip()), output) # noqa
+
+    def test_custom_vcl_error_added(self):
+        # Given When
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'domain_name=www.domain.com',
+            '-var', 'backend_address=1.1.1.1',
+            '-var', 'env=ci',
+            '-var', 'custom_vcl_error=baz',
+            '-target=module.fastly',
+            '-no-color',
+            'test/infra'
+        ], env=self._env_for_check_output('qwerty')).decode('utf-8')
+
+        # Then
+        assert re.search(template_to_re("""
+      vcl.{ident}.content:                       "c851607eec588af067851810ffa5be84f1083e91"
+      vcl.{ident}.main:                          "true"
+      vcl.{ident}.name:                          "custom_vcl"
         """.strip()), output) # noqa

--- a/variables.tf
+++ b/variables.tf
@@ -99,3 +99,9 @@ variable "custom_vcl_recv" {
   description = "Custom VCL to add to the vcl_recv sub after the Fastly hook"
   default     = ""
 }
+
+variable "custom_vcl_error" {
+  type        = "string"
+  description = "Custom VCL to add to the vcl_error sub after the Fastly hook"
+  default     = ""
+}


### PR DESCRIPTION
This will allow us to exit vcl_recv with an error to bypass the cache
and backend, and then issue a synthetic response from vcl_error (in
order to do redirects).

JIRA: PLAT-345