### PR TITLE
Remove the live special case

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -136,7 +136,7 @@ data "template_file" "custom_vcl" {
 # resource performing bare-domain redirection to prefix; only for live
 resource "fastly_service_v1" "fastly_bare_domain_redirection" {
   name  = "${var.domain_name}-redirection"
-  count = "${var.env == "live" && var.bare_redirect_domain_name != "" ? 1 : 0}"
+  count = "${var.bare_redirect_domain_name != "" ? 1 : 0}"
 
   domain {
     name = "${var.bare_redirect_domain_name}"


### PR DESCRIPTION
So we can (for example) redirect ci.debtwire.com to ci-www.debtwire.com.

JIRA: PLAT-345