### PR TITLE
Simplify cache setting

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,18 +33,14 @@ resource "fastly_service_v1" "fastly" {
   # Set force-miss (disables caching) and force-ssl (enables redirect from HTTP
   # -> HTTPS for all requests) settings
   request_setting {
-    name              = "disable caching"
-    request_condition = "all_urls"
-    force_miss        = "${var.caching == "false" ? true : false}"
+    name              = "request-setting"
     force_ssl         = "${var.force_ssl}"
     bypass_busy_wait  = "${var.bypass_busy_wait}"
   }
 
-  condition {
-    name      = "all_urls"
-    priority  = "10"
-    statement = "req.url ~ \".*\""
-    type      = "REQUEST"
+  cache_setting {
+    name   = "cache-setting"
+    action = "${var.caching == "false" ? "pass" : "cache"}"
   }
 
   # Override requests for /robots.txt for non-live environments
@@ -162,7 +158,6 @@ resource "fastly_service_v1" "fastly_bare_domain_redirection" {
     name              = "redirect_bare_domain_to_prefix"
     status            = 301
     response          = "Moved Permanently"
-    request_condition = "all_urls"
   }
 
   header {
@@ -171,14 +166,6 @@ resource "fastly_service_v1" "fastly_bare_domain_redirection" {
     type              = "response"
     action            = "set"
     source            = "\"https://${local.full_domain_name}\" + req.url"
-    request_condition = "all_urls"
-  }
-
-  condition {
-    name      = "all_urls"
-    type      = "REQUEST"
-    priority  = 5
-    statement = "req.url ~ \".*\""
   }
 
   logentries {

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -259,7 +259,7 @@ Plan: 3 to add, 0 to change, 0 to destroy.
       condition.{ident}.type:                     "REQUEST"
         """.strip()), output) # noqa
 
-    def test_force_ssl_and_caching_enabled_by_default(self):
+    def test_force_ssl_enabled_by_default(self):
         # given
 
         # when
@@ -280,15 +280,39 @@ Plan: 3 to add, 0 to change, 0 to destroy.
       request_setting.{ident}.action:            ""
       request_setting.{ident}.bypass_busy_wait:  "false"
       request_setting.{ident}.default_host:      ""
-      request_setting.{ident}.force_miss:        "false"
+      request_setting.{ident}.force_miss:        ""
       request_setting.{ident}.force_ssl:         "true"
       request_setting.{ident}.geo_headers:       ""
       request_setting.{ident}.hash_keys:         ""
       request_setting.{ident}.max_stale_age:     ""
-      request_setting.{ident}.name:              "disable caching"
-      request_setting.{ident}.request_condition: "all_urls"
+      request_setting.{ident}.name:              "request-setting"
+      request_setting.{ident}.request_condition: ""
       request_setting.{ident}.timer_support:     ""
       request_setting.{ident}.xff:               "append"
+        """.strip()), output) # noqa
+
+    def test_caching_enabled_by_default(self):
+        # given
+
+        # when
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'domain_name=www.domain.com',
+            '-var', 'backend_address=1.1.1.1',
+            '-var', 'env=ci',
+            '-no-color',
+            '-target=module.fastly',
+            'test/infra'
+        ], env=self._env_for_check_output('qwerty')).decode('utf-8')
+
+        assert re.search(template_to_re("""
+      cache_setting.#:                              "1"
+      cache_setting.{ident}.action:              "cache"
+      cache_setting.{ident}.cache_condition:     ""
+      cache_setting.{ident}.name:                "cache-setting"
+      cache_setting.{ident}.stale_ttl:           ""
+      cache_setting.{ident}.ttl:                 ""
         """.strip()), output) # noqa
 
     def test_disable_caching(self):
@@ -307,19 +331,12 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 
         # then
         assert re.search(template_to_re("""
-      request_setting.#:                            "1"
-      request_setting.{ident}.action:            ""
-      request_setting.{ident}.bypass_busy_wait:  "false"
-      request_setting.{ident}.default_host:      ""
-      request_setting.{ident}.force_miss:        "true"
-      request_setting.{ident}.force_ssl:         "true"
-      request_setting.{ident}.geo_headers:       ""
-      request_setting.{ident}.hash_keys:         ""
-      request_setting.{ident}.max_stale_age:     ""
-      request_setting.{ident}.name:              "disable caching"
-      request_setting.{ident}.request_condition: "all_urls"
-      request_setting.{ident}.timer_support:     ""
-      request_setting.{ident}.xff:               "append"
+      cache_setting.#:                              "1"
+      cache_setting.{ident}.action:              "pass"
+      cache_setting.{ident}.cache_condition:     ""
+      cache_setting.{ident}.name:                "cache-setting"
+      cache_setting.{ident}.stale_ttl:           ""
+      cache_setting.{ident}.ttl:                 ""
         """.strip()), output) # noqa
 
     def test_disable_force_ssl(self):
@@ -342,13 +359,13 @@ Plan: 3 to add, 0 to change, 0 to destroy.
       request_setting.{ident}.action:            ""
       request_setting.{ident}.bypass_busy_wait:  "false"
       request_setting.{ident}.default_host:      ""
-      request_setting.{ident}.force_miss:        "false"
+      request_setting.{ident}.force_miss:        ""
       request_setting.{ident}.force_ssl:         "false"
       request_setting.{ident}.geo_headers:       ""
       request_setting.{ident}.hash_keys:         ""
       request_setting.{ident}.max_stale_age:     ""
-      request_setting.{ident}.name:              "disable caching"
-      request_setting.{ident}.request_condition: "all_urls"
+      request_setting.{ident}.name:              "request-setting"
+      request_setting.{ident}.request_condition: ""
       request_setting.{ident}.timer_support:     ""
       request_setting.{ident}.xff:               "append"
         """.strip()), output) # noqa


### PR DESCRIPTION
This causes the request and response to bypass the cache, rather than
just forcing a miss and allowing the response to be cached. Also, the
all urls conditions are unneccessary since this is the default.