### PR TITLE
Remove override host

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,6 @@ resource "fastly_service_v1" "fastly" {
     name = "${local.full_domain_name}"
   }
 
-  default_host = "${local.full_domain_name}"
   default_ttl  = 60
 
   backend {

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -69,10 +69,6 @@ class TestTFFastlyFrontend(unittest.TestCase):
         ], env=self._env_for_check_output('qwerty')).decode('utf-8')
 
         # Then
-        assert """
-      default_host:                                 "ci-www.domain.com"
-        """.strip() in output
-
         assert re.search(template_to_re("""
       domain.#:                                     "1"
       domain.{ident}.comment:                    ""


### PR DESCRIPTION
This should always be the Host header anyway, and this helps with origin shielding apparently