### PR TITLE
Add shield parameter for default backend

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "fastly_service_v1" "fastly" {
     name = "${local.full_domain_name}"
   }
 
-  default_ttl  = 60
+  default_ttl = 60
 
   backend {
     address               = "${var.backend_address}"
@@ -21,6 +21,7 @@ resource "fastly_service_v1" "fastly" {
     connect_timeout       = "${var.connect_timeout}"
     first_byte_timeout    = "${var.first_byte_timeout}"
     between_bytes_timeout = "${var.between_bytes_timeout}"
+    shield                = "${var.shield}"
   }
 
   gzip {
@@ -32,9 +33,9 @@ resource "fastly_service_v1" "fastly" {
   # Set force-miss (disables caching) and force-ssl (enables redirect from HTTP
   # -> HTTPS for all requests) settings
   request_setting {
-    name              = "request-setting"
-    force_ssl         = "${var.force_ssl}"
-    bypass_busy_wait  = "${var.bypass_busy_wait}"
+    name             = "request-setting"
+    force_ssl        = "${var.force_ssl}"
+    bypass_busy_wait = "${var.bypass_busy_wait}"
   }
 
   cache_setting {
@@ -154,17 +155,17 @@ resource "fastly_service_v1" "fastly_bare_domain_redirection" {
   }
 
   response_object {
-    name              = "redirect_bare_domain_to_prefix"
-    status            = 301
-    response          = "Moved Permanently"
+    name     = "redirect_bare_domain_to_prefix"
+    status   = 301
+    response = "Moved Permanently"
   }
 
   header {
-    name              = "redirect_bare_domain_to_prefix"
-    destination       = "http.Location"
-    type              = "response"
-    action            = "set"
-    source            = "\"https://${local.full_domain_name}\" + req.url"
+    name        = "redirect_bare_domain_to_prefix"
+    destination = "http.Location"
+    type        = "response"
+    action      = "set"
+    source      = "\"https://${local.full_domain_name}\" + req.url"
   }
 
   logentries {

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,17 +1,10 @@
 FROM python:3-alpine3.6
 COPY requirements.txt .
 
-ENV TERRAFORM_VERSION=0.11.1
+ENV TERRAFORM_VERSION=0.11.7
 
-ENV TERRAFORM_PROVIDER_AWS_VERSION=1.6.0
-ENV TERRAFORM_PROVIDER_FASTLY_VERSION=0.1.3
+ENV TERRAFORM_PROVIDER_FASTLY_VERSION=0.1.4
 ENV TERRAFORM_PROVIDER_LOGENTRIES_VERSION=0.1.0_logset_datasource
-ENV TERRAFORM_PROVIDER_NULL_VERSION=1.0.0
-ENV TERRAFORM_PROVIDER_TEMPLATE_VERSION=1.0.0
-ENV TERRAFORM_PROVIDER_ACME_VERSION=0.3.0
-ENV TERRAFORM_PROVIDER_EXTERNAL_VERSION=1.0.0
-ENV TERRAFORM_PROVIDER_TLS_VERSION=1.0.1
-ENV TERRAFORM_PROVIDER_DATADOG_VERSION=1.0.3
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/latest-stable/main >> /etc/apk/repositories
 RUN apk update
@@ -20,24 +13,10 @@ RUN apk -U add gcc musl-dev libffi-dev openssl-dev docker curl git zip unzip wge
 RUN cd /tmp && \
     curl -sSLO https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
         unzip terraform_*_linux_amd64.zip -d /usr/bin && \
-    curl -sSLO https://releases.hashicorp.com/terraform-provider-aws/$TERRAFORM_PROVIDER_AWS_VERSION/terraform-provider-aws_${TERRAFORM_PROVIDER_AWS_VERSION}_linux_amd64.zip && \
-        unzip terraform-provider-aws_*_linux_amd64.zip -d /usr/bin && \
     curl -sSLO https://releases.hashicorp.com/terraform-provider-fastly/$TERRAFORM_PROVIDER_FASTLY_VERSION/terraform-provider-fastly_${TERRAFORM_PROVIDER_FASTLY_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-fastly_*_linux_amd64.zip -d /usr/bin && \
     wget -q https://s3-eu-west-1.amazonaws.com/mmg-terraform-providers/terraform-provider-logentries_v${TERRAFORM_PROVIDER_LOGENTRIES_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-logentries_*_linux_amd64.zip -d /usr/bin && \
-    curl -sSLO https://releases.hashicorp.com/terraform-provider-null/$TERRAFORM_PROVIDER_NULL_VERSION/terraform-provider-null_${TERRAFORM_PROVIDER_NULL_VERSION}_linux_amd64.zip && \
-        unzip terraform-provider-null_*_linux_amd64.zip -d /usr/bin && \
-    curl -sSLO https://releases.hashicorp.com/terraform-provider-template/$TERRAFORM_PROVIDER_TEMPLATE_VERSION/terraform-provider-template_${TERRAFORM_PROVIDER_TEMPLATE_VERSION}_linux_amd64.zip && \
-        unzip terraform-provider-template_*_linux_amd64.zip -d /usr/bin && \
-    wget -q https://github.com/paybyphone/terraform-provider-acme/releases/download/v${TERRAFORM_PROVIDER_ACME_VERSION}/terraform-provider-acme_v${TERRAFORM_PROVIDER_ACME_VERSION}_linux_amd64.zip && \
-        unzip terraform-provider-acme_*_linux_amd64.zip -d /usr/bin && \
-    curl -sSLO https://releases.hashicorp.com/terraform-provider-external/$TERRAFORM_PROVIDER_EXTERNAL_VERSION/terraform-provider-external_${TERRAFORM_PROVIDER_EXTERNAL_VERSION}_linux_amd64.zip && \
-        unzip terraform-provider-external_*_linux_amd64.zip -d /usr/bin && \
-    curl -sSLO https://releases.hashicorp.com/terraform-provider-tls/$TERRAFORM_PROVIDER_TLS_VERSION/terraform-provider-tls_${TERRAFORM_PROVIDER_TLS_VERSION}_linux_amd64.zip && \
-        unzip terraform-provider-tls*_linux_amd64.zip -d /usr/bin && \
-    curl -sSLO https://releases.hashicorp.com/terraform-provider-datadog/$TERRAFORM_PROVIDER_DATADOG_VERSION/terraform-provider-datadog_${TERRAFORM_PROVIDER_DATADOG_VERSION}_linux_amd64.zip && \
-        unzip terraform-provider-datadog*_linux_amd64.zip -d /usr/bin && \
     rm -rf /tmp/* && \
     rm -rf /var/tmp/*
 

--- a/variables.tf
+++ b/variables.tf
@@ -107,7 +107,13 @@ variable "custom_vcl_error" {
 }
 
 variable "bypass_busy_wait" {
-  type = "string"
+  type        = "string"
   description = "Disable collapsed forwarding, so you don't wait for other objects to origin."
-  default = "false"
+  default     = "false"
+}
+
+variable "shield" {
+  type        = "string"
+  description = "PoP to use as an origin shield (e.g. london-uk for Slough)."
+  default     = ""
 }


### PR DESCRIPTION
This will also be applied for custom backends created with
tf_fastly_routing_config since the shield config is put at the end of
the fastly provided config in vcl_recv (after the default backend is
set), before the custom routing is applied. This has slightly different
semantics than if you created all the routing outside of VCL - this
will hopefully be fixed by a future fastly terraform provider that
allows us to model things with their resources rather than resorting to
VCL.

JIRA: PLAT-1427