### PR TITLE
Don't execute vcl_recv on shield nodes

### DIFF
--- a/custom.vcl
+++ b/custom.vcl
@@ -7,7 +7,9 @@ ${custom_vcl_backends}
 sub vcl_recv {
 #FASTLY recv
 
-${custom_vcl_recv}
+if (! req.http.fastly-ff) {
+  ${custom_vcl_recv}
+}
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);


### PR DESCRIPTION
We only want to run this once at the edge.