### PR TITLE
Fix cache condition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,8 @@ resource "fastly_service_v1" "fastly" {
     name      = "prevent-caching"
     type      = "CACHE"
     priority  = 5
-    statement = "! ${var.caching}"
+    # if caching is on, then do not match and do not apply cache setting
+    statement = "req.url ${ var.caching == "true" ? "!" : "" }~ \"^\""
   }
 
   cache_setting {

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -348,7 +348,7 @@ Plan: 3 to add, 0 to change, 0 to destroy.
         assert re.search(template_to_re("""
       condition.{ident}.name:      "prevent-caching"
       condition.{ident}.priority:  "5"
-      condition.{ident}.statement: "! true"
+      condition.{ident}.statement: "req.url !~ \\"^\\""
       condition.{ident}.type:      "CACHE"
         """.strip()), output) # noqa
 
@@ -378,7 +378,7 @@ Plan: 3 to add, 0 to change, 0 to destroy.
         assert re.search(template_to_re("""
       condition.{ident}.name:      "prevent-caching"
       condition.{ident}.priority:  "5"
-      condition.{ident}.statement: "! false"
+      condition.{ident}.statement: "req.url ~ \\"^\\""
       condition.{ident}.type:      "CACHE"
         """.strip()), output) # noqa
 


### PR DESCRIPTION
Seems that you can't have boolean literals in conditions, nor can you
have comparisons beteen literals (i.e. no `"true" == "false"`). While
the workaround is a little convoluted, hopefully still not too difficult
to understand.