### PR TITLE
Disable caching by returning pass from vcl_recv

### DIFF
--- a/custom.vcl
+++ b/custom.vcl
@@ -19,7 +19,7 @@ sub vcl_recv {
     return(pass);
   }
 
-  return(lookup);
+  return(${vcl_recv_default_action});
 }
 
 sub vcl_fetch {

--- a/main.tf
+++ b/main.tf
@@ -30,26 +30,10 @@ resource "fastly_service_v1" "fastly" {
     content_types = ["text/html", "text/css", "application/json"]
   }
 
-  # Set force-miss (disables caching) and force-ssl (enables redirect from HTTP
-  # -> HTTPS for all requests) settings
   request_setting {
     name             = "request-setting"
     force_ssl        = "${var.force_ssl}"
     bypass_busy_wait = "${var.bypass_busy_wait}"
-  }
-
-  condition {
-    name      = "prevent-caching"
-    type      = "CACHE"
-    priority  = 5
-    # if caching is on, then do not match and do not apply cache setting
-    statement = "req.url ${ var.caching == "true" ? "!" : "" }~ \"^\""
-  }
-
-  cache_setting {
-    name            = "cache-setting"
-    action          = "pass"
-    cache_condition = "prevent-caching"
   }
 
   # Override requests for /robots.txt for non-live environments
@@ -152,6 +136,7 @@ data "template_file" "custom_vcl" {
     custom_vcl_recv_no_shield   = "${var.custom_vcl_recv_no_shield}"
     custom_vcl_recv_shield_only = "${var.custom_vcl_recv_shield_only}"
     custom_vcl_error            = "${var.custom_vcl_error}"
+    vcl_recv_default_action     = "${var.caching == "true" ? "lookup" : "pass"}"
   }
 }
 

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -337,19 +337,9 @@ Plan: 3 to add, 0 to change, 0 to destroy.
             'test/infra'
         ], env=self._env_for_check_output('qwerty')).decode('utf-8')
 
+        # then
         assert re.search(template_to_re("""
-      cache_setting.{ident}.action:          "pass"
-      cache_setting.{ident}.cache_condition: "prevent-caching"
-      cache_setting.{ident}.name:            "cache-setting"
-      cache_setting.{ident}.stale_ttl:       ""
-      cache_setting.{ident}.ttl:             ""
-        """.strip()), output) # noqa
-
-        assert re.search(template_to_re("""
-      condition.{ident}.name:      "prevent-caching"
-      condition.{ident}.priority:  "5"
-      condition.{ident}.statement: "req.url !~ \\"^\\""
-      condition.{ident}.type:      "CACHE"
+      vcl.{ident}.content:                       "d74b2a0b3f4a7fc8a09d9d1a9d1261049bbb161d"
         """.strip()), output) # noqa
 
     def test_disable_caching(self):
@@ -368,18 +358,7 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 
         # then
         assert re.search(template_to_re("""
-      cache_setting.{ident}.action:          "pass"
-      cache_setting.{ident}.cache_condition: "prevent-caching"
-      cache_setting.{ident}.name:            "cache-setting"
-      cache_setting.{ident}.stale_ttl:       ""
-      cache_setting.{ident}.ttl:             ""
-        """.strip()), output) # noqa
-
-        assert re.search(template_to_re("""
-      condition.{ident}.name:      "prevent-caching"
-      condition.{ident}.priority:  "5"
-      condition.{ident}.statement: "req.url ~ \\"^\\""
-      condition.{ident}.type:      "CACHE"
+      vcl.{ident}.content:                       "baf93e86203d6212936d6659924ca81d8d58db85"
         """.strip()), output) # noqa
 
     def test_disable_force_ssl(self):


### PR DESCRIPTION
This is the method recommend at
https://docs.fastly.com/guides/debugging/temporarily-disabling-caching.html