### PR TITLE
Changing the name of the output to include syslog

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,7 +163,7 @@ resource "fastly_service_v1" "fastly" {
   }
 
   syslog {
-    name            = "${local.full_domain_name}"
+    name            = "${local.full_domain_name}-syslog"
     address         = "intake.logs.datadoghq.com"
     port            = "10516"
     message_type    = "blank"

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -106,7 +106,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
         syslog.{ident}.format:                      " '%h %l %u %t \\"%r\\" %>s %b'"
         syslog.{ident}.format_version:              "2"
         syslog.{ident}.message_type:                "blank"
-        syslog.{ident}.name:                        "ci-www.domain.com"
+        syslog.{ident}.name:                        "ci-www.domain.com-syslog"
         syslog.{ident}.port:                        "10516"
         syslog.{ident}.response_condition:          ""
           """.strip()), output)  # noqa


### PR DESCRIPTION
This is currently breaking as anything using logentries is already using
the specified name. So adding -syslog to the end should get around this.