### PR TITLE
Set default_host explicitly

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ resource "fastly_service_v1" "fastly" {
     name = "${local.full_domain_name}"
   }
 
+  default_host = "${local.full_domain_name}"
   default_ttl = 60
 
   backend {

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -769,3 +769,22 @@ Plan: 2 to add, 0 to change, 0 to destroy.
       vcl.{ident}.main:    "true"
       vcl.{ident}.name:    "custom_vcl"
         """.strip()), output)  # noqa
+
+    def test_explicit_default_host(self):
+        # Given When
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'domain_name=www.domain.com',
+            '-var', 'backend_address=1.1.1.1',
+            '-var', 'env=ci',
+            '-target=module.fastly',
+            '-no-color',
+            'test/infra'
+        ], env=self._env_for_check_output('qwerty')).decode('utf-8')
+
+        # Then
+        assert re.search(template_to_re("""
+        default_host: "ci-www.domain.com"
+        """.strip()), output)  # noqa
+        #default_host:                                 "ci-www.domain.com"\n'

--- a/test/test_tf_fastly_frontend.py
+++ b/test/test_tf_fastly_frontend.py
@@ -787,4 +787,3 @@ Plan: 2 to add, 0 to change, 0 to destroy.
         assert re.search(template_to_re("""
         default_host: "ci-www.domain.com"
         """.strip()), output)  # noqa
-        #default_host:                                 "ci-www.domain.com"\n'


### PR DESCRIPTION
I'd prefer we didn't set this, but it appears that with the absence of a
setting something is picking one - for the debtwire frontend router this
is the correct value, for cms-acuris-com-router it is picking the
backend address, which breaks routing via shield. Explicitly setting to
none also appears to be problematic:

https://github.com/terraform-providers/terraform-provider-fastly/issues/85
https://github.com/terraform-providers/terraform-provider-fastly/issues/75